### PR TITLE
introduce nested omp parallel for to parallelize over events in CPU code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,30 @@
-CMSSW_CUDAUTILS_PATH=/home/beiwang/clustering/cmssw
+CMSSW_CUDAUTILS_PATH=../cmssw
 #git clone https://github.com/cms-patatrack/cmssw.git
 EXTERNAL_SOURCE = ${CMSSW_CUDAUTILS_PATH}/HeterogeneousCore/CUDAUtilities/src
-CUDA_API_PATH=/home/beiwang/clustering/cuda-api-wrappers/src
+CUDA_API_PATH=../cuda-api-wrappers/src
 #git clone https://github.com/cms-externals/cuda-api-wrappers.git
 
 CC = g++
 CXXFLAGS += -std=c++14 -O3 -fopenmp -fopt-info-vec -march=native \
- -I${CUDA_PATH}/include -I${CMSSW_CUDAUTILS_PATH} -I${CUDA_API_PATH} -DUSE_GPU -DCACHE_ALLOC #-DOUTPUT #-DCPU_DEBUG
-LDFLAGS += -std=c++14 -O3 -fopenmp -march=native
+ -I${CUDA_PATH}/include -I${CMSSW_CUDAUTILS_PATH} -I${CUDA_API_PATH} \
+ -mprefer-vector-width=512 #-DUSE_GPU -DCACHE_ALLOC #-DOUTPUT #-DCPU_DEBUG
+LDFLAGS += -std=c++14 -O3 -fopenmp -march=native -mprefer-vector-width=512
 
 #CC = icpc
 #CXXFLAGS += -std=c++14 -O3 -qopenmp -qopt-report=5 -xHost \
-# -I${CUDA_PATH}/include -DOUTPUT #-DUSE_GPU
-#LDFLAGS += -std=c++14 -O3 -fopenmp -xHost
+# -I${CUDA_PATH}/include -I${CMSSW_CUDAUTILS_PATH} -I${CUDA_API_PATH} \
+# -qopt-zmm-usage=high #-DOUTPUT #-DUSE_GPU
+#LDFLAGS += -std=c++14 -O3 -fopenmp -xHost -qopt-zmm-usage=high
 
 NVCC = nvcc
-CUBROOT=/home/beiwang/clustering/cub-1.8.0
+CUBROOT=../cub-1.8.0
 #git clone https://github.com/NVlabs/cub.git
 CUDAFLAGS += -std=c++14 -O3 --default-stream per-thread --ptxas-options=-v \
  -gencode=arch=compute_60,code=\"sm_60,compute_60\"  \
  -I${CUBROOT} -I${CMSSW_CUDAUTILS_PATH} -I${CUDA_API_PATH} -DCUB_STDERR \
-#-DGPU_TIMER #-DCACHE_ALLOC #-DGPU_TIMER #-DUSE_TEXTURE -DGPU_DEBUG
+ -DGPU_TIMER #-DCACHE_ALLOC #-DUSE_TEXTURE -DGPU_DEBUG
 # Note: -arch=sm_60 == -gencode=arch=compute_60,code=\"sm_60,compute_60\"
-CUDALDFLAGS += -lcudart -L${CMSSW_CUDAUTILS_PATH}/HeterogeneousCore/CUDAUtilities/src
+CUDALDFLAGS += -lcudart -L${CUDALIBDIR}
 
 strip-cluster : strip-cluster.o cluster.o clusterGPU.o allocate_host.o allocate_device.o
 	$(CC) $(LDFLAGS) $(CUDALDFLAGS) -o strip-cluster strip-cluster.o cluster.o \

--- a/cluster.cc
+++ b/cluster.cc
@@ -228,7 +228,7 @@ void setSeedStripsNCIndex(sst_data_t *sst_data, calib_data_t *calib_data, cpu_ti
 
 #ifdef CPU_DEBUG
   for (int i=0; i<nStrips; i++) {
-    if (seedStripNCMask[i])
+    if (seedStripsNCMask[i])
       std::cout<<" i "<<i<<" mask "<<seedStripsNCMask[i]<<" prefix "<<prefixSeedStripsNCMask[i]<<" index "<<seedStripsNCIndex[i]<<std::endl;
   }
   std::cout<<"nStrips="<<nStrips<<"nSeedStripsNC="<<sst_data->nSeedStripsNC<<std::endl;

--- a/strip-cluster.cc
+++ b/strip-cluster.cc
@@ -102,6 +102,8 @@ int main()
   }
   cudaDeviceSynchronize();
 #else
+  omp_set_nested(true);
+#pragma omp parallel for num_threads(5)
   for (int i=0; i<nStreams; i++) {
 
     setSeedStripsNCIndex(sst_data[i], calib_data, cpu_timing[i]);
@@ -152,6 +154,7 @@ int main()
   std::cout<<" findBoundary function Time "<<cpu_timing[0]->findBoundaryTime<<std::endl;
   std::cout<<" checkCluster function Time "<<cpu_timing[0]->checkClusterTime<<std::endl;
   std::cout<<" Total Time "<<t1-t0<<std::endl;
+  std::cout<<"nested? "<<omp_get_nested()<<std::endl;
 #endif
 
 #ifdef USE_GPU


### PR DESCRIPTION
Advice on the number of nested threads... I found that on a machine with dual Skylakes (Intel Xeon Gold 6142), in which 32 physical cores are available, the fastest run time was obtained with "omp parallel for num_threads(5)" for the outer loop (as hard-coded in this PR), and OMP_NUM_THREADS=4 in the environment, where this variable pertains to the inner parallel sections. Due to the nesting of the OpenMP constructs, this means 20 total threads should be active while the inner parallel sections are running. Given the above settings, the "Total Time" reported by the CPU-only code was cut by about 1/3. It's unclear why more threads aren't helpful. Possibly the memory bandwidth gets saturated.

Note, one random typo is fixed in cluster.cc. Note also that I keep tweaking the Makefile to see if I can make it work on the Princeton system as well as mine.

To do... if the nesting capability is worth keeping, then a timer besides omp_get_wtime() might be necessary for timing individual functions on the CPU. Measuring CPU time might be more relevant.

PS to Bei: is there some way we can just download or clone the small piece of CMSSW that is needed? It seems a waste to clone a 1 GB repository just to get a small amount of code.