### PR TITLE
take nStreams from OMP_NUM_THREADS and adjust nIter; set -arch by site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ifneq (,$(findstring tigergpu, $(SYSTEMS)))
 	CUBROOT=/home/beiwang/clustering/cub-1.8.0
 #git clone https://github.com/cms-externals/cuda-api-wrappers.git
 	CUDA_API_PATH=/home/beiwang/clustering/cuda-api-wrappers/src
+	GPUARCH=sm_60
 endif 
 
 #lnx7188 at cornell
@@ -16,6 +17,7 @@ ifneq (,$(findstring lnx7188, $(SYSTEMS)))
 	CMSSW_CUDAUTILS_PATH=../cmssw
 	CUBROOT=../cub-1.8.0
 	CUDA_API_PATH=../cuda-api-wrappers/src
+	GPUARCH=sm_70
 endif
 
 EXTERNAL_SOURCE = ${CMSSW_CUDAUTILS_PATH}/HeterogeneousCore/CUDAUtilities/src
@@ -38,12 +40,11 @@ endif
 
 NVCC = nvcc
 CUDAFLAGS += -std=c++14 -O3 --default-stream per-thread --ptxas-options=-v \
- -gencode=arch=compute_60,code=\"sm_60,compute_60\"  \
- -I${CUBROOT} -I${CMSSW_CUDAUTILS_PATH} -I${CUDA_API_PATH} \
- -DCACHE_ALLOC #-DGPU_TIMER #-DUSE_TEXTURE -DGPU_DEBUG -DCUB_STDERR
-# Note: -arch=sm_60 == -gencode=arch=compute_60,code=\"sm_60,compute_60\"
+ -arch=${GPUARCH} -I${CUBROOT} -I${CMSSW_CUDAUTILS_PATH} -I${CUDA_API_PATH} \
+ -DCACHE_ALLOC -DGPU_TIMER #-DUSE_TEXTURE -DGPU_DEBUG -DCUB_STDERR
+ # Note: -arch=sm_60 == -gencode=arch=compute_60,code=\"sm_60,compute_60\"
 CUDALDFLAGS += -lcudart -L${CUDALIBDIR} \
--L${CMSSW_CUDAUTILS_PATH}/HeterogeneousCore/CUDAUtilities/src
+ -L${CMSSW_CUDAUTILS_PATH}/HeterogeneousCore/CUDAUtilities/src
 
 strip-cluster : strip-cluster.o cluster.o clusterGPU.o allocate_host.o allocate_device.o
 	$(CC) $(LDFLAGS) $(CUDALDFLAGS) -o strip-cluster strip-cluster.o cluster.o \

--- a/strip-cluster.cc
+++ b/strip-cluster.cc
@@ -14,8 +14,8 @@ int main()
 {
   const int max_strips = 600000;
   const int max_seedstrips = 150000;
-  const int nIter = 100;
-  const int nStreams = 8;
+  const int nStreams = omp_get_max_threads();
+  const int nIter = 840/nStreams;
   cudaStream_t stream[nStreams];
   sst_data_t *sst_data[nStreams];
   clust_data_t *clust_data[nStreams];


### PR DESCRIPTION
This commit makes sure that nStreams is always equal to the number of OpenMP threads (at the first nesting level), as intended. Also, it guarantees that 840 events will always be processed (or really the same event will be processed 840 times), regardless of the number of streams.

Previously OMP_NUM_THREADS=5 worked very well when nStreams=10=const., because 10 is evenly divisible by 5. The parallel loop over nStreams was therefore executed in parallel exactly twice with nothing left over.  In contrast, 10 is not evenly divisible by other small integers like 3 and 4, so those numbers did not work well for OMP_NUM_THREADS.

In the proposed new definition of nIter, I am choosing 840 because it is close to both 800 and 1000 (recalling that ``` nIter*nStreams = 100*10``` previously), and because 840 is nicely divisible by many small integers: ```840 = 3*5*7*8```.

Finally, the V100 GPUs on lnx7188 are compatible with -arch=sm_70, and there is some chance the code will run better if this option is given to nvcc. (Thus far I have not observed a difference.)
